### PR TITLE
made --add-options and --vendor-* jlink plugins persistent

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2631,6 +2631,16 @@ public final class System {
                                                       Continuation continuation) {
                 return StackWalker.newInstance(options, null, contScope, continuation);
             }
+
+            @Override
+            public String getVendorPropertyFieldValue(String name) {
+                switch (name) {
+                    case "VENDOR_VERSION": return VersionProps.VENDOR_VERSION;
+                    case "VENDOR_URL_BUG": return VersionProps.VENDOR_URL_BUG;
+                    case "VENDOR_URL_VM_BUG": return VersionProps.VENDOR_URL_VM_BUG;
+                    default: throw new InternalError("Unknown VersionProps field: " + name);
+                }
+            }            
         });
     }
 }

--- a/src/java.base/share/classes/java/lang/VersionProps.java.template
+++ b/src/java.base/share/classes/java/lang/VersionProps.java.template
@@ -79,18 +79,21 @@ class VersionProps {
         "@@VENDOR_URL@@";
 
     // The remaining VENDOR_* fields must not be final,
-    // so that they can be redefined by jlink plugins
+    // so that they can be redefined by jlink plugins.
+    // They must also not be private so that they can
+    // be read by JavaLangAccess.
 
-    // This field is read by HotSpot
-    private static String VENDOR_VERSION =
+    // This field is read by HotSpot and JavaLangAccess.
+    static String VENDOR_VERSION =
         "@@VENDOR_VERSION_STRING@@";
 
-    private static String VENDOR_URL_BUG =
+    // This field is read by JavaLangAccess.
+    static String VENDOR_URL_BUG =
         "@@VENDOR_URL_BUG@@";
 
-    // This field is read by HotSpot
+    // This field is read by HotSpot and JavaLangAccess.
     @SuppressWarnings("unused")
-    private static String VENDOR_URL_VM_BUG =
+    static String VENDOR_URL_VM_BUG =
         "@@VENDOR_URL_VM_BUG@@";
 
     /**

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -537,4 +537,8 @@ public interface JavaLangAccess {
     StackWalker newStackWalkerInstance(Set<StackWalker.Option> options,
                                        ContinuationScope contScope,
                                        Continuation continuation);
+    /**
+     * Gets the value of the field named {@code name} in {@code java.lang.VersionProps}.
+     */
+    String getVendorPropertyFieldValue(String name);
 }


### PR DESCRIPTION
Changes in this PR:
* The `--add-options` option value is persistent: A `--add-options` value specified when creating image1 is prepended to the `--add-options` value specified when running `image1/bin/jlink`.
* The `--vendor-*` option values are persistent.