### PR TITLE
Add a -XX:+UseGraalJIT VM flag

### DIFF
--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -48,6 +48,14 @@ class fileStream;
   product(bool, EnableJVMCI, false, EXPERIMENTAL,                           \
           "Enable JVMCI")                                                   \
                                                                             \
+  product(bool, UseGraalJIT, false,                                         \
+          "Select the Graal JVMCI compiler. This is a macro for: "          \
+          "  -XX:+UnlockExperimentalVMOptions "                             \
+          "  -XX:+EnableJVMCIProduct "                                      \
+          "  -XX:+UseJVMCICompiler "                                        \
+          "  -Djvmci.Compiler=graal "                                       \
+          "  -XX:-UnlockExperimentalVMOptions")                             \
+                                                                            \
   product(bool, EnableJVMCIProduct, false, EXPERIMENTAL,                    \
           "Allow JVMCI to be used in product mode. This alters a subset of "\
           "JVMCI flags to be non-experimental, defaults UseJVMCICompiler "  \


### PR DESCRIPTION
This change adds support for `-XX:+UseGraalJIT` as a macro VM flag for:
```
-XX:+UnlockExperimentalVMOptions
-XX:+EnableJVMCIProduct
-XX:+UseJVMCICompiler
-Djvmci.Compiler=graal
-XX:-UnlockExperimentalVMOptions
```

It allows for a customer to use a supported and branded Graal-compiler based JIT in a JDK product.

I've tested it with a drop-in copy of the libgraal library:
```
> cp libjvmcicompiler.dylib ~/jdk-jdk/open/build/macosx-aarch64/images/jdk/lib
> ~/jdk-jdk/open/build/macosx-aarch64/images/jdk/bin/java -XX:+UseGraalJIT -Dgraal.ShowConfiguration=info -cp ~/Dropbox/bin CountUppercase
[Use -Dgraal.LogFile=<path> to redirect Graal log output to a file.]
Using "Graal Community compiler with Truffle extensions" loaded from a Native Image shared library
1 (97 ms)
2 (92 ms)
3 (89 ms)
4 (82 ms)
5 (71 ms)
6 (72 ms)
7 (75 ms)
8 (69 ms)
9 (69 ms)
total: 0 (785 ms)
```

Removing the libgraal library provides a sensible error message:
```
> rm ~/jdk-jdk/open/build/macosx-aarch64/images/jdk/lib/libjvmcicompiler.dylib
> ~/jdk-jdk/open/build/macosx-aarch64/images/jdk/bin/java -XX:+UseGraalJIT -Dgraal.ShowConfiguration=info -cp ~/Dropbox/bin CountUppercase
JVMCI compiler 'graal' specified by jvmci.Compiler not found
```