### PR TITLE
Using tristate  CompilerThread::_can_call_java.

### DIFF
--- a/src/hotspot/share/compiler/compilerThread.cpp
+++ b/src/hotspot/share/compiler/compilerThread.cpp
@@ -56,7 +56,9 @@ CompilerThread::~CompilerThread() {
 
 void CompilerThread::set_compiler(AbstractCompiler* c) {
   // Only jvmci compiler threads can call Java
-  _can_call_java = c != nullptr && c->is_jvmci();
+  if (c != nullptr && c->is_jvmci()) {
+      _can_call_java = TriBool{};
+  }
   _compiler = c;
 }
 

--- a/src/hotspot/share/compiler/compilerThread.hpp
+++ b/src/hotspot/share/compiler/compilerThread.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_COMPILER_COMPILERTHREAD_HPP
 #define SHARE_COMPILER_COMPILERTHREAD_HPP
 
+#include <utilities/tribool.hpp>
 #include "runtime/javaThread.hpp"
 
 class AbstractCompiler;
@@ -50,7 +51,7 @@ class CompilerThread : public JavaThread {
   CompileTask* volatile _task;  // print_threads_compiling can read this concurrently.
   CompileQueue*         _queue;
   BufferBlob*           _buffer_blob;
-  bool                  _can_call_java;
+  TriBool               _can_call_java;
 
   AbstractCompiler*     _compiler;
   TimeStamp             _idle_time;
@@ -73,7 +74,7 @@ class CompilerThread : public JavaThread {
 
   bool is_Compiler_thread() const                { return true; }
 
-  virtual bool can_call_java() const             { return _can_call_java; }
+  virtual bool can_call_java() const             { return _can_call_java.is_default() || _can_call_java; }
 
   // Returns true if this CompilerThread is hidden from JVMTI and FlightRecorder.  C1 and C2 are
   // always hidden but JVMCI compiler threads might be hidden.

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1372,7 +1372,7 @@ JVMCIObject JVMCIEnv::get_jvmci_type(const JVMCIKlassHandle& klass, JVMCI_TRAPS)
   JavaThread* THREAD = JVMCI::compilation_tick(JavaThread::current()); // For exception macros.
   jboolean exception = false;
   if (is_hotspot()) {
-    CompilerThreadCanCallJava ccj(THREAD, true);
+    CompilerThreadCanCallJava ccj(THREAD, true, true);
     JavaValue result(T_OBJECT);
     JavaCallArguments args;
     args.push_long(pointer);

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -1516,10 +1516,12 @@ final class CompilerToVM {
     native void getOopMapAt(HotSpotResolvedJavaMethodImpl method, long methodPointer, int bci, long[] oopMap);
 
     /**
-     * If the current thread is a CompilerThread associated with a JVMCI compiler where
-     * newState != CompilerThread::_can_call_java, then _can_call_java is set to newState.
+     * If the current thread is a {@code CompilerThread} associated with a JVMCI compiler where
+     * {@code newState != CompilerThread::_can_call_java}, then {@code _can_call_java} is set
+     * to {@code newState}.
      *
-     * @returns false if no change was made, otherwise true
+     * @return the previous {@code _can_call_java} value if change was made,
+     * otherwise {@code newState}
      */
-    native boolean updateCompilerThreadCanCallJava(boolean newState);
+    native int updateCompilerThreadCanCallJava(int newState);
 }


### PR DESCRIPTION
1. ` CompilerThread::_can_call_java` now has 3 states, true, false, default.
2. `CompilerThreadCanCallJava::update` allows only transition from the default state unless `force=true`.

The crashing test for Truffle call target inlining done by CompileBroker thread now passes fine. But I need to run other test to be sure that we didn't break some other feature with this change.